### PR TITLE
Add borrowers.cardnumber to select statement in query

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/PatronOverdueNotices.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/PatronOverdueNotices.pm
@@ -130,6 +130,7 @@ sub report_step2 {
             borrowers.address,
             borrowers.address2,
             borrowers.borrowernumber,
+            borrowers.cardnumber,
             borrowers.branchcode,
             borrowers.city,
             borrowers.email,


### PR DESCRIPTION
This patch fixes a bug where the patron's card number does not appear in the results table the plugin generates.